### PR TITLE
release v0.3.4

### DIFF
--- a/packages/nx-cmake/src/generators/preset/generator.spec.ts
+++ b/packages/nx-cmake/src/generators/preset/generator.spec.ts
@@ -3,7 +3,6 @@ import type { WorkspaceLayout } from '../../models/types';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { readNxJson } from '@nx/devkit';
 import presetGenerator from './generator';
-import * as devkit from '@nx/devkit';
 
 describe('preset generator', () => {
     let tree: Tree;
@@ -15,7 +14,6 @@ describe('preset generator', () => {
             appsDir: 'bin',
             libsDir: 'libs',
         };
-        jest.spyOn(devkit, 'formatFiles').mockImplementation(jest.fn());
     });
 
     afterEach(() => {

--- a/packages/nx-cmake/src/generators/preset/generator.ts
+++ b/packages/nx-cmake/src/generators/preset/generator.ts
@@ -6,7 +6,6 @@ import {
 } from '@nx/devkit';
 import type { InitGeneratorSchema } from '../init/schema';
 import initGenerator from '../init/generator';
-import { formatFiles } from '@nx/devkit';
 import { generateReadMe } from './utils/generateReadMe/generateReadMe';
 import { PLUGIN_NAME } from '../../config/pluginName';
 
@@ -28,7 +27,6 @@ export async function presetGenerator(tree: Tree) {
     );
     return async () => {
         installPackagesTask(tree);
-        await formatFiles(tree);
     };
 }
 

--- a/packages/nx-cmake/src/generators/preset/utils/generateReadMe/generateReadMe.spec.ts
+++ b/packages/nx-cmake/src/generators/preset/utils/generateReadMe/generateReadMe.spec.ts
@@ -160,7 +160,7 @@ describe('generateReadMe', () => {
 
     it('should generate README.md', () => {
         generateReadMe(tree, name);
-        const result = readFileWithTree(tree, `${tree.root}/README.md`);
+        const result = readFileWithTree(tree, `README.md`);
         expect(result).toStrictEqual(expectedReadMe);
     });
 });

--- a/packages/nx-cmake/src/generators/preset/utils/generateReadMe/generateReadMe.ts
+++ b/packages/nx-cmake/src/generators/preset/utils/generateReadMe/generateReadMe.ts
@@ -3,7 +3,7 @@ import { generateFiles } from '@nx/devkit';
 import { join } from 'path';
 
 export const generateReadMe = (tree: Tree, name: string): void => {
-    generateFiles(tree, join(__dirname, '../../', 'template'), tree.root, {
+    generateFiles(tree, join(__dirname, '../../', 'template'), '.', {
         name,
     });
 };


### PR DESCRIPTION
- fix(nx-cmake): format and lint target have ci config, generators format files
- chore(nx-cmake): bump deps, update readme
- fix(nx-cmake): function names are now camelCase
- fix(nx-cmake): update readme when using preset generator and install prettier
- chore(nx-cmake): format
- fix(nx-cmake): preset generator
